### PR TITLE
Update full name for `GitHub Copilot` to `GitHub Copilot coding agent`

### DIFF
--- a/generate_chart.py
+++ b/generate_chart.py
@@ -23,7 +23,7 @@ AGENTS = [
     {
         "key": "copilot",
         "display": "Copilot",
-        "long_name": "GitHub Copilot",
+        "long_name": "GitHub Copilot coding agent",
         "color": "#2563eb",
         "info_url": "https://docs.github.com/en/copilot/using-github-copilot/coding-agent/using-copilot-to-work-on-an-issue",
         "total_query_url": "https://github.com/search?q=is:pr+head:copilot/&type=pullrequests",

--- a/generate_chart.py
+++ b/generate_chart.py
@@ -25,7 +25,7 @@ AGENTS = [
         "display": "Copilot",
         "long_name": "GitHub Copilot coding agent",
         "color": "#2563eb",
-        "info_url": "https://docs.github.com/en/copilot/using-github-copilot/coding-agent/using-copilot-to-work-on-an-issue",
+        "info_url": "https://docs.github.com/en/copilot/how-tos/use-copilot-agents/coding-agent",
         "total_query_url": "https://github.com/search?q=is:pr+head:copilot/&type=pullrequests",
         "merged_query_url": "https://github.com/search?q=is:pr+head:copilot/+is:merged&type=pullrequests",
         "ready_query_url": "https://github.com/search?q=is:pr+head:copilot/+-is:draft&type=pullrequests",


### PR DESCRIPTION
👋 I'm Tim, and I'm the product leader for GitHub Copilot coding agent.

Thanks for putting together this great resource for tracking and comparing autonomous developer agents!

I'd like to propose updating the full name for `GitHub Copilot` to `GitHub Copilot coding agent`.

This will make it clear and unambiguous exactly what product is part of the comparison, and avoid confusion with GitHub Copilot agent mode in various IDEs.