### PR TITLE
Slow down GitHub API polling

### DIFF
--- a/collect_data.py
+++ b/collect_data.py
@@ -7,6 +7,10 @@ import requests
 import time
 
 
+# Delay between API requests to respect rate limits
+API_DELAY_SECONDS = float(os.getenv("API_DELAY_SECONDS", 2))
+
+
 # GitHub API headers with optional authentication
 def get_headers():
     headers = {"Accept": "application/vnd.github+json", "User-Agent": "PR-Watcher"}
@@ -81,7 +85,7 @@ def collect_data():
                     time.sleep(10)  # Wait 10 seconds before retry
 
         # Rate limiting: wait between API calls
-        time.sleep(1.0)
+        time.sleep(API_DELAY_SECONDS)
 
     # Save data to CSV
     timestamp = dt.datetime.now(dt.UTC).strftime("%Y‑%m‑%d %H:%M:%S")


### PR DESCRIPTION
## Summary
- add `API_DELAY_SECONDS` constant to configure GitHub API request pacing
- use constant for inter-request delays to increase default wait to 2 seconds

## Testing
- `python -m py_compile collect_data.py`


------
https://chatgpt.com/codex/tasks/task_b_68a7158c7d6c8332a6f24661f9ec84f8