### PR TITLE
Handle GitHub rate limits

### DIFF
--- a/collect_data.py
+++ b/collect_data.py
@@ -7,6 +7,10 @@ import requests
 import time
 
 
+# Delay between API requests to respect rate limits
+API_DELAY_SECONDS = float(os.getenv("API_DELAY_SECONDS", 2))
+
+
 # GitHub API headers with optional authentication
 def get_headers():
     headers = {"Accept": "application/vnd.github+json", "User-Agent": "PR-Watcher"}
@@ -68,20 +72,36 @@ def collect_data():
                     headers=headers,
                     timeout=30,
                 )
+
+                # If rate limited, wait until reset and retry
+                if (
+                    r.status_code == 403
+                    and r.headers.get("X-RateLimit-Remaining") == "0"
+                ):
+                    reset = int(r.headers.get("X-RateLimit-Reset", 0))
+                    wait_for = max(reset - time.time(), 0) + 1
+                    print(
+                        f"    Rate limit exceeded, sleeping for {int(wait_for)}s before retry"
+                    )
+                    time.sleep(wait_for)
+                    continue
+
                 r.raise_for_status()
                 cnt[key] = r.json()["total_count"]
                 print(f"  {key}: {cnt[key]}")
                 break
-                
+
             except Exception as e:
                 if attempt == max_attempts - 1:  # Last attempt - fail the job
                     raise e
                 else:
-                    print(f"    Attempt {attempt + 1} failed, retrying...")
+                    print(
+                        f"    Attempt {attempt + 1} failed ({e}), retrying in 10s..."
+                    )
                     time.sleep(10)  # Wait 10 seconds before retry
 
         # Rate limiting: wait between API calls
-        time.sleep(1.0)
+        time.sleep(API_DELAY_SECONDS)
 
     # Save data to CSV
     timestamp = dt.datetime.now(dt.UTC).strftime("%Y‑%m‑%d %H:%M:%S")


### PR DESCRIPTION
## Summary
- wait for GitHub rate limit reset when API requests return 403
- log exception details on failed attempts to aid debugging

## Testing
- `python -m py_compile collect_data.py`


------
https://chatgpt.com/codex/tasks/task_b_68a7158c7d6c8332a6f24661f9ec84f8